### PR TITLE
Upgrade to 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 2.1.0
+- Add process.env.API_HOST, process.env.API_PORT, process.env.API_PROTOCOL and process.env.API_DEFAULT_VERSION
+variables for clients to overwrite the api config 
+
 ### 2.0.1
 - store slug in payload if action error occurs 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "twreporter-redux",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "redux actions and reducers for twreporter website",
   "main": "lib/index.js",
   "scripts": {

--- a/src/conf/api-config.json
+++ b/src/conf/api-config.json
@@ -1,10 +1,7 @@
 {
-  "API_PROTOCOL_ON_CLIENT": "https",
-  "API_HOST_ON_CLIENT": "dev-go-api.twreporter.org",
-  "API_PORT_ON_CLIENT": "443",
-  "API_PROTOCOL_ON_SERVER": "http",
-  "API_HOST_ON_SERVER": "go-api",
-  "API_PORT_ON_SERVER": "8080",
-  "API_DEFAULT_VERSION": "v1",
+  "API_PROTOCOL": "https",
+  "API_HOST": "go-api.twreporter.org",
+  "API_PORT": "443",
+  "API_DEFAULT_VERSION": "/v1/",
   "API_TIME_OUT": 3000
 }

--- a/src/utils/form-api-url.js
+++ b/src/utils/form-api-url.js
@@ -4,23 +4,21 @@ const formAPIURL = (path, toEncode = true) => {
   let protocol
   let host
   let port
+  let version
   const _path = toEncode ? encodeURI(path) : path
   if (process.env.NODE_ENV === 'development') {
-    return `http://localhost:8080/v1/${_path}`
-  }
-
-  // process.env.BROWSER is defined in next.config.js
-  if (process.env.BROWSER) {
-    protocol = config.API_PROTOCOL_ON_CLIENT
-    host = config.API_HOST_ON_CLIENT
-    port = config.API_PORT_ON_CLIENT
+    protocol = process.env.API_PROTOCOL || 'http'
+    host = process.env.API_HOST || 'localhost'
+    port = process.env.API_PORT || '8080'
+    version = process.env.API_DEFAULT_VERSION || '/v1/'
   } else {
-    protocol = config.API_PROTOCOL_ON_SERVER
-    host = config.API_HOST_ON_SERVER
-    port = config.API_PORT_ON_SERVER
+    protocol = process.env.API_PROTOCOL || config.API_PROTOCOL
+    host = process.env.API_HOST || config.API_HOST
+    port = process.env.API_PORT || config.API_PORT
+    version = process.env.API_DEFAULT_VERSION || config.API_DEFAULT_VERSION
   }
 
-  return `${protocol}://${host}:${port}/v1/${_path}`
+  return `${protocol}://${host}:${port}${version}${_path}`
 }
 
 export default formAPIURL


### PR DESCRIPTION
- Add process.env.API_HOST, process.env.API_PORT,
process.env.API_PROTOCOL and process.env.API_DEFAULT_VERSION
variables for clients to overwrite the api config