### PR TITLE
Update src/actions/error-action-creators.js: remove `request` object from payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Release
 
+### 5.0.3
+
+- Update src/actions/error-action-creators.js: remove `request` object from payload
+
+
 ### 5.0.2
 
 - Add settings action/recuder for redux store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/redux",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "redux actions and reducers for twreporter website",
   "main": "lib/index.js",
   "scripts": {

--- a/src/actions/error-action-creators.js
+++ b/src/actions/error-action-creators.js
@@ -60,7 +60,6 @@ function handleAxiosError(err = {}, failActionType) {
       type: failActionType,
       payload: {
         message: 'A request was made but no response was received.',
-        request: _.get(err, 'request'),
         config: _.get(err, 'config'),
       },
     }


### PR DESCRIPTION
### Change Reason
In `twreporter-react/src/helpers/Html.js`, the program will try to [`serialize(store.getState())`](https://github.com/twreporter/twreporter-react/blob/master/src/helpers/Html.js#L60), and `request` object will make `TypeError: Converting circular structure to JSON` error.

